### PR TITLE
fog-awsインストール, production環境のみS3を使うように設定を追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -68,6 +68,10 @@ group :test do
   gem 'webdrivers'
 end
 
+group :production do
+  gem 'fog-aws'
+end
+
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -108,9 +108,26 @@ GEM
       dotenv (= 2.7.6)
       railties (>= 3.2)
     erubi (1.10.0)
+    excon (0.91.0)
     faker (2.19.0)
       i18n (>= 1.6, < 2)
     ffi (1.15.5)
+    fog-aws (3.13.0)
+      fog-core (~> 2.1)
+      fog-json (~> 1.1)
+      fog-xml (~> 0.1)
+    fog-core (2.2.4)
+      builder
+      excon (~> 0.71)
+      formatador (~> 0.2)
+      mime-types
+    fog-json (1.2.0)
+      fog-core
+      multi_json (~> 1.10)
+    fog-xml (0.1.4)
+      fog-core
+      nokogiri (>= 1.5.11, < 2.0.0)
+    formatador (0.3.0)
     globalid (1.0.0)
       activesupport (>= 5.0)
     i18n (1.9.1)
@@ -153,11 +170,15 @@ GEM
     marcel (1.0.2)
     matrix (0.4.2)
     method_source (1.0.0)
+    mime-types (3.4.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2022.0105)
     mini_magick (4.11.0)
     mini_mime (1.1.2)
     mini_portile2 (2.7.1)
     minitest (5.15.0)
     msgpack (1.4.4)
+    multi_json (1.15.0)
     mysql2 (0.5.3)
     nio4r (2.5.8)
     nokogiri (1.13.1)
@@ -313,6 +334,7 @@ DEPENDENCIES
   devise
   dotenv-rails
   faker
+  fog-aws
   jbuilder (~> 2.7)
   kaminari
   letter_opener_web
@@ -340,4 +362,4 @@ RUBY VERSION
    ruby 2.7.5p203
 
 BUNDLED WITH
-   2.3.6
+   2.3.7

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -3,10 +3,6 @@ class ImageUploader < CarrierWave::Uploader::Base
   # include CarrierWave::RMagick
   include CarrierWave::MiniMagick
 
-  # Choose what kind of storage to use for this uploader:
-  storage :file
-  # storage :fog
-
   # Override the directory where uploaded files will be stored.
   # This is a sensible default for uploaders that are meant to be mounted:
   def store_dir
@@ -14,6 +10,14 @@ class ImageUploader < CarrierWave::Uploader::Base
   end
 
   process resize_to_limit: [400, 300]
+
+  # Choose what kind of storage to use for this uploader:
+  if Rails.env.development? || Rails.env.test?
+    storage :file
+  else
+    storage :fog
+  end
+  
 
   # Provide a default URL as a default if there hasn't been a file uploaded:
   # def default_url(*args)

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -13,7 +13,7 @@ CarrierWave.configure do |config|
       provider: 'AWS',
       aws_access_key_id: ENV["AWS_ACCESS_KEY_ID"],
       aws_secret_access_key: ENV["AWS_SECRET_ACCESS_KEY"],
-      region: 'ap_northeast-1',
+      region: 'ap-northeast-1',
       path_style: true
     }
     config.fog_public  = true

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -16,10 +16,11 @@ CarrierWave.configure do |config|
       region: 'ap-northeast-1',
       path_style: true
     }
-    config.fog_public  = true
+    #config.fog_public  = true
+    config.fog_public  = false
     config.fog_attributes = {'Cache-Control' => 'public, max-age=86400'}
-    config.fog_directory  = 'smr2-production' #S3のバケット名
-    config.asset_host = 'https://s3-ap-northeast-1.amazonaws.com/smr2-production'
+    config.fog_directory  = 'smr22-production' #S3のバケット名
+    config.asset_host = 'https://s3-ap-northeast-1.amazonaws.com'
   else
     config.storage :file # 開発環境:public/uploades下に保存
     config.enable_processing = false if Rails.env.test? #test:処理をスキップ

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -1,0 +1,27 @@
+# coding: utf-8
+# CarrierWaveの設定呼び出し
+require 'carrierwave/storage/abstract'
+require 'carrierwave/storage/file'
+require 'carrierwave/storage/fog'
+
+# 保存先の分岐
+CarrierWave.configure do |config|
+  if Rails.env.production? # 本番環境:AWS使用
+    config.storage = :fog
+    config.fog_provider = 'fog/aws'
+    config.fog_credentials = {
+      provider: 'AWS',
+      aws_access_key_id: ENV["AWS_ACCESS_KEY_ID"],
+      aws_secret_access_key: ENV["AWS_SECRET_ACCESS_KEY"],
+      region: 'ap_northeast-1',
+      path_style: true
+    }
+    config.fog_public  = true
+    config.fog_attributes = {'Cache-Control' => 'public, max-age=86400'}
+    config.fog_directory  = 'smr2-production' #S3のバケット名
+    config.asset_host = 'https://s3-ap-northeast-1.amazonaws.com/smr2-production'
+  else
+    config.storage :file # 開発環境:public/uploades下に保存
+    config.enable_processing = false if Rails.env.test? #test:処理をスキップ
+  end  
+end

--- a/public/404.html
+++ b/public/404.html
@@ -2,66 +2,8 @@
 <html>
 <head>
   <title>The page you were looking for doesn't exist (404)</title>
-  <meta name="viewport" content="width=device-width,initial-scale=1">
-  <style>
-  .rails-default-error-page {
-    background-color: #EFEFEF;
-    color: #2E2F30;
-    text-align: center;
-    font-family: arial, sans-serif;
-    margin: 0;
-  }
-
-  .rails-default-error-page div.dialog {
-    width: 95%;
-    max-width: 33em;
-    margin: 4em auto 0;
-  }
-
-  .rails-default-error-page div.dialog > div {
-    border: 1px solid #CCC;
-    border-right-color: #999;
-    border-left-color: #999;
-    border-bottom-color: #BBB;
-    border-top: #B00100 solid 4px;
-    border-top-left-radius: 9px;
-    border-top-right-radius: 9px;
-    background-color: white;
-    padding: 7px 12% 0;
-    box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
-  }
-
-  .rails-default-error-page h1 {
-    font-size: 100%;
-    color: #730E15;
-    line-height: 1.5em;
-  }
-
-  .rails-default-error-page div.dialog > p {
-    margin: 0 0 1em;
-    padding: 1em;
-    background-color: #F7F7F7;
-    border: 1px solid #CCC;
-    border-right-color: #999;
-    border-left-color: #999;
-    border-bottom-color: #999;
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
-    border-top-color: #DADADA;
-    color: #666;
-    box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
-  }
-  </style>
 </head>
-
-<body class="rails-default-error-page">
-  <!-- This file lives in public/404.html -->
-  <div class="dialog">
-    <div>
-      <h1>The page you were looking for doesn't exist.</h1>
-      <p>You may have mistyped the address or the page may have moved.</p>
-    </div>
-    <p>If you are the application owner check the logs for more information.</p>
-  </div>
+<body>
+<img src="/404.png">
 </body>
 </html>

--- a/public/500.html
+++ b/public/500.html
@@ -2,65 +2,8 @@
 <html>
 <head>
   <title>We're sorry, but something went wrong (500)</title>
-  <meta name="viewport" content="width=device-width,initial-scale=1">
-  <style>
-  .rails-default-error-page {
-    background-color: #EFEFEF;
-    color: #2E2F30;
-    text-align: center;
-    font-family: arial, sans-serif;
-    margin: 0;
-  }
-
-  .rails-default-error-page div.dialog {
-    width: 95%;
-    max-width: 33em;
-    margin: 4em auto 0;
-  }
-
-  .rails-default-error-page div.dialog > div {
-    border: 1px solid #CCC;
-    border-right-color: #999;
-    border-left-color: #999;
-    border-bottom-color: #BBB;
-    border-top: #B00100 solid 4px;
-    border-top-left-radius: 9px;
-    border-top-right-radius: 9px;
-    background-color: white;
-    padding: 7px 12% 0;
-    box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
-  }
-
-  .rails-default-error-page h1 {
-    font-size: 100%;
-    color: #730E15;
-    line-height: 1.5em;
-  }
-
-  .rails-default-error-page div.dialog > p {
-    margin: 0 0 1em;
-    padding: 1em;
-    background-color: #F7F7F7;
-    border: 1px solid #CCC;
-    border-right-color: #999;
-    border-left-color: #999;
-    border-bottom-color: #999;
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
-    border-top-color: #DADADA;
-    color: #666;
-    box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
-  }
-  </style>
 </head>
-
-<body class="rails-default-error-page">
-  <!-- This file lives in public/500.html -->
-  <div class="dialog">
-    <div>
-      <h1>We're sorry, but something went wrong.</h1>
-    </div>
-    <p>If you are the application owner check the logs for more information.</p>
-  </div>
+<body>
+<img src="/500.png">
 </body>
 </html>


### PR DESCRIPTION
## S3パケット作成
- 名前　		smr22-production
- ユーザ          新規にgroup_iam_appを作成し RDSとS3のフルアクセス権限を追加し、このグループにアプリ用の新規ユーザを追加し、このユーザでバケット作成
- アクセス許可 パブリックアクセスをすべてブロック（デフォルト）

## アプリ側ソース変更
- config/initializer/carrierwave.rb（新規）
			S3保存先の設定など
- app/uploader/image_uploader.rb
			fog-aws( developmentではfile, productionではfogを使用する) 設定

## 発生/解決した問題 (production.logにて確認）
### ResolvError
  リージョン名の誤記が原因
### Excon::Error::BadRequest: Expected(200) <=> Actual(400 Bad Request)
  config/initialize/carrierwave.rbでバケットのアクセス許可をパブリックに指定していたため不一致だったのが原因
```
    config.fog_public  = true  # --> falseに変更で解決
```
